### PR TITLE
Snyk monitor instead of snyk test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: Run Snyk dependency vulnerability scan
           command: |
             npx snyk auth $SNYK_TOKEN
-            npx snyk test --all-projects
+            npx snyk monitor --all-projects
 
       - run:
           name: Run Snyk code vulnerability scan


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the story behind this PR, as if explaining
     to a non-technical person. Or to an LLM so it can learn from it for
     future (autonomous) code improvements. Feel free to point to a deeper
     design doc, if applicable.
-->
This PR fixes that CCI job fails in case snyk test fails. Instead it always goes through and sends the data to snyk dashboard which is what we want.

## Connected Issues
<!-- Have you cared to connect this PR to a work item in DevRev, so that we
     can understand future routing and attribution?
-->
- https://app.devrev.ai/devrev/works/ISS-194882

## Craftsmanship, Integrity, and Devil’s Advocacy
<!-- Mark the appropriate option with an "x" -->
- [ ] Testing: Negative test cases: null or default values, crash and fault injection tests
- [ ] Testing: Boundary conditions: rolling upgrades, denial-of-service, etc.
- [ ] Testing: Fixing a few existing — flaky or permanently-broken — test cases
- [ ] Observing: Detailed error codes so machines can understand
- [ ] Observing: Adding superior metrics for future debugging
- [ ] Observing: Tracing the hairiest pathways for field serviceability
- [ ] Training: KnowledgeOps update? So AI always works.

## Story of the craft
<!-- *“Wisdom is knowing the right path to take. Integrity is taking it.”*

    Show-n-tell the story of testing, observing, or training from above.
    Take your time. Your stories will teach others the craft.
-->
