### PR TITLE
Fix task denormalization bug and add warning for non-existing user in Asana

### DIFF
--- a/code/src/functions/asana/data-denormalization.ts
+++ b/code/src/functions/asana/data-denormalization.ts
@@ -10,7 +10,6 @@ export function denormalizeTask(item: any, projectId?: string) {
   }
 
   if (item.data?.assignee != null) {
-    data.assignee = item.data.assignee.external || null;
     if ('external' in item.data.assignee) {
       data.assignee = item.data.assignee.external;
     } else {

--- a/code/src/functions/asana/data-denormalization.ts
+++ b/code/src/functions/asana/data-denormalization.ts
@@ -3,12 +3,29 @@
 // payload shape of external system requests, extracting relevant properties (such as the assignee, name, and notes). 
 
 export function denormalizeTask(item: any, projectId?: string) {
-  return {
-    data: {
-      assignee: item.data?.assignee?.external,
-      name: item.data?.name || '',
-      notes: item.data?.description?.content?.[0] ? item.data?.description?.content?.[0] : '',
-      ...(projectId && { projects: [projectId] }),
-    },
-  };
+  const data: any = {};
+
+  if (item.data?.name) {
+    data.name = item.data?.name || '';
+  }
+
+  if (item.data?.assignee) {
+    data.assignee = item.data.assignee.external || null;
+    if ('external' in item.data.assignee) {
+      data.assignee = item.data.assignee.external;
+    } else {
+      data.assignee = null;
+      console.warn(`Given DevRev user (${item.data.assignee.devrev}) does not exist in Asana.`);
+    }
+  }
+
+  if (item.data?.description) {
+    data.notes = item.data?.description?.content?.[0] || '';
+  }
+  
+  if (projectId) {
+    data.projects = [projectId];
+  }
+
+  return { data };
 }

--- a/code/src/functions/asana/data-denormalization.ts
+++ b/code/src/functions/asana/data-denormalization.ts
@@ -5,11 +5,11 @@
 export function denormalizeTask(item: any, projectId?: string) {
   const data: any = {};
 
-  if (item.data?.name) {
+  if (item.data?.name != null) {
     data.name = item.data?.name || '';
   }
 
-  if (item.data?.assignee) {
+  if (item.data?.assignee != null) {
     data.assignee = item.data.assignee.external || null;
     if ('external' in item.data.assignee) {
       data.assignee = item.data.assignee.external;
@@ -19,11 +19,11 @@ export function denormalizeTask(item: any, projectId?: string) {
     }
   }
 
-  if (item.data?.description) {
+  if (item.data?.description != null) {
     data.notes = item.data?.description?.content?.[0] || '';
   }
   
-  if (projectId) {
+  if (projectId != null) {
     data.projects = [projectId];
   }
 


### PR DESCRIPTION
# Description

This pull request solves the bug inside `denormalizeTask` function where all fields were reset for all updated issues (instead of just changed ones). 
This change also adds logging to cases where an issue owner on DevRev does not exist on Asana.

## Connected Issues

https://app.devrev.ai/devrev/works/ISS-203379

## How to test?

1. Create an import
2. Change issue owner in DevRev to a user that doesn't exist in Asana
3. Sync DevRev to Asana
4. The task assignee in Asana should be unassigned and there should be a warning about it