### PR TITLE
chore: upgrade @devrev/ts-adaas to 1.19.7 and fix npm audit issues

### DIFF
--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@devrev/ts-adaas": "1.19.4",
+        "@devrev/ts-adaas": "1.19.7",
         "axios": "^1.9.0",
         "axios-retry": "4.5.0",
         "form-data": "4.0.5"
@@ -623,12 +623,12 @@
       }
     },
     "node_modules/@devrev/ts-adaas": {
-      "version": "1.19.4",
-      "resolved": "https://registry.npmjs.org/@devrev/ts-adaas/-/ts-adaas-1.19.4.tgz",
-      "integrity": "sha512-CVqpyUOGVF9Hqj9RgkSw7/1UZhIN/BDl7gMpT8xf3pTpPEpVAyHlpF/j5iBBX9RlcTfXDNnErfMuBUS5YinFug==",
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/@devrev/ts-adaas/-/ts-adaas-1.19.7.tgz",
+      "integrity": "sha512-74LPjgv78ShYpImWfSouqe9UfO00lDvVKAy9V9L6I7n8bI2R1pauipuwu8PNo5W4dauS15q9Qodn6cE64lrhOA==",
       "license": "ISC",
       "dependencies": {
-        "@devrev/typescript-sdk": "^1.1.59",
+        "@devrev/typescript-sdk": "^1.1.74",
         "axios": "^1.15.2",
         "axios-retry": "^4.5.0",
         "form-data": "^4.0.4",
@@ -638,13 +638,13 @@
       }
     },
     "node_modules/@devrev/typescript-sdk": {
-      "version": "1.1.71",
-      "resolved": "https://registry.npmjs.org/@devrev/typescript-sdk/-/typescript-sdk-1.1.71.tgz",
-      "integrity": "sha512-fO9JPf+THibohRhOcoS3nmcQ+cb77X3q16u2KrGAj4tQm8TYbgfFk/uMLD2zpAHA/GtQybXE89+HiTsqhYlhrQ==",
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/@devrev/typescript-sdk/-/typescript-sdk-1.1.75.tgz",
+      "integrity": "sha512-fs23g4i62QcMjHP7CROFkJLa3KFupJ+f/pf/qo33QEKnae84gCoyV2xqjEjEoXFgegrWfNnGEzhO6oC7F65CgQ==",
       "license": "MIT",
       "dependencies": {
         "@types/yargs": "^17.0.22",
-        "axios": "^1.12.0",
+        "axios": "^1.15.2",
         "dotenv": "^16.0.3",
         "protobufjs": "^7.3.0",
         "yargs": "^17.6.2"
@@ -1707,19 +1707,18 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -1729,9 +1728,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -2887,9 +2886,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2901,7 +2900,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -4074,15 +4073,15 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -4101,7 +4100,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -4609,9 +4608,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4995,9 +4994,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6438,9 +6437,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7050,24 +7049,24 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7184,9 +7183,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -7680,14 +7679,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/code/package.json
+++ b/code/package.json
@@ -54,7 +54,7 @@
     "yargs": "^17.6.2"
   },
   "dependencies": {
-    "@devrev/ts-adaas": "1.19.4",
+    "@devrev/ts-adaas": "1.19.7",
     "axios": "^1.9.0",
     "axios-retry": "4.5.0",
     "form-data": "4.0.5"


### PR DESCRIPTION
### `airdrop-asana-snap-in`

#### Summary

Upgraded `@devrev/ts-adaas` from `1.19.4` to `1.19.7` and ran `npm audit fix` to resolve auto-fixable vulnerabilities in `airdrop-asana-snap-in`. Lockfile regenerated; `npm run build` passes on the upgrade branch.

#### Connected Issues

https://app.devrev.ai/devrev/issue/ASCPT-3

#### Craftsmanship, Integrity, and Devil's Advocacy

- **Testing:** Negative test cases / crash and fault injection — `npm test` ran (best-effort) on the upgrade branch; the build script (`npm run build`) passes on the changed package.
- **Testing:** Boundary conditions: rolling upgrades, denial-of-service — N/A; this is a dependency-only change, no runtime networking or parsing logic was modified.
- **Testing:** Fixing flaky or broken tests touched by this change — None added or changed by this work.
- **Observing:** Detailed error codes for machines — N/A.
- **Observing:** Metrics for future debugging — N/A.
- **Observing:** Tracing for field serviceability — N/A.
- **Training:** KnowledgeOps / docs update for AI or humans — N/A.

#### Packages touched

| package.json        | Change summary                                                                                         |
| ---------------------| --------------------------------------------------------------------------------------------------------|
| `code/package.json` | bump `@devrev/ts-adaas` `1.19.4` → `1.19.7`; lockfile regenerated by `npm install` and `npm audit fix` |

#### npm audit mapping

| Phase  | info | low | moderate | high | critical | total |
| --------| ------| -----| ----------| ------| ----------| -------|
| Before | 0    | 0   | 5        | 0    | 0        | 5     |
| After  | 0    | 0   | 0        | 0    | 0        | 0     |

#### Remaining audit items

None — `npm audit` clean for fixable items at the time of this change.

#### Story of the craft

Bumped the DevRev Airdrop SDK to its latest published release (`1.19.7`) and let `npm audit fix` resolve transitive vulnerabilities surfaced by the refreshed lockfile. The change is the smallest safe correction: pinning style was preserved, no source code was touched, and `npm run build` passes on the upgrade branch.

**Branch:** [`chore/sdk-upgrade-and-audit`](https://github.com/devrev/airdrop-asana-snap-in/tree/chore/sdk-upgrade-and-audit)